### PR TITLE
refactor: use whiskers

### DIFF
--- a/Themes/Catppuccin Frappe.css
+++ b/Themes/Catppuccin Frappe.css
@@ -1,7 +1,7 @@
-/* Frappe */
+/* Frappé */
 :root {
   --rosewater: hsl(10, 57%, 88%);
-  --flamingo: hsl(0, 59%, 84%);
+  --flamingo: hsl(0, 58%, 84%);
   --pink: hsl(316, 73%, 84%);
   --mauve: hsl(277, 59%, 76%);
   --red: hsl(359, 68%, 71%);
@@ -382,50 +382,50 @@ style.value.identifier.function {
 }
 
 terminal.black {
-  color: #45475a;
+  color: #51576d;
 }
 terminal.blue {
-  color: #89b4fa;
+  color: #8caaee;
 }
 terminal.red {
-  color: #f38ba8;
+  color: #e78284;
 }
 terminal.green {
-  color: #a6e3a1;
+  color: #a6d189;
 }
 terminal.yellow {
-  color: #f9e2af;
+  color: #e5c890;
 }
 terminal.magenta {
-  color: #f5c2e7;
+  color: #f4b8e4;
 }
 terminal.cyan {
-  color: #94e2d5;
+  color: #81c8be;
 }
 terminal.white {
-  color: #bac2de;
+  color: #a5adce;
 }
 terminal.bright-black {
-  color: #585b70;
+  color: #626880;
 }
 terminal.bright-white {
-  color: #a6adc8;
+  color: #a5adce;
 }
 terminal.bright-blue {
-  color: #89b4fa;
+  color: #8caaee;
 }
 terminal.bright-red {
-  color: #f38ba8;
+  color: #e78284;
 }
 terminal.bright-green {
-  color: #a6e3a1;
+  color: #a6d189;
 }
 terminal.bright-yellow {
-  color: #f9e2af;
+  color: #e5c890;
 }
 terminal.bright-magenta {
-  color: #f5c2e7;
+  color: #f4b8e4;
 }
 terminal.bright-cyan {
-  color: #94e2d5;
+  color: #81c8be;
 }

--- a/Themes/Catppuccin Latte.css
+++ b/Themes/Catppuccin Latte.css
@@ -10,12 +10,12 @@
   --yellow: hsl(35, 77%, 49%);
   --green: hsl(109, 58%, 40%);
   --teal: hsl(183, 74%, 35%);
-  --sky: hsl(197, 97%, 46%);
+  --sky: hsl(197, 96%, 46%);
   --sapphire: hsl(189, 70%, 42%);
   --blue: hsl(220, 91%, 54%);
   --lavender: hsl(231, 97%, 72%);
-  --text: hsl(234, 16%, 35%);
-  --subtext1: hsl(233, 13%, 41%);
+  --text: hsl(234, 16%, 36%);
+  --subtext1: hsl(233, 13%, 42%);
   --subtext0: hsl(233, 10%, 47%);
   --overlay2: hsl(232, 10%, 53%);
   --overlay1: hsl(231, 10%, 59%);
@@ -29,7 +29,7 @@
 }
 
 meta {
-  -theme-interface-style: light;
+  -theme-interface-style: dark;
   -theme-accent-color: hsl(0, 59%, 88%);
 }
 
@@ -48,14 +48,14 @@ meta.titlebar.inactive {
 }
 
 meta.button {
-  background: linear-gradient(hsl(223, 16%, 83%), hsl(225, 14%, 77%));
-  border: linear-gradient(hsl(223, 16%, 83%), hsl(225, 14%, 77%));
-  color: hsl(234, 16%, 35%);
+  background: linear-gradient(hsl(225, 14%, 77%), hsl(223, 16%, 83%));
+  border: linear-gradient(hsl(225, 14%, 77%), hsl(223, 16%, 83%));
+  color: hsl(11, 59%, 67%);
 }
 meta.button.highlighted {
   background: linear-gradient(hsl(227, 12%, 71%), hsl(225, 14%, 77%));
-  border: linear-gradient(hsl(227, 12%, 71%), hsl(223, 16%, 83%));
-  color: hsl(223, 16%, 83%);
+  border: linear-gradient(hsl(227, 12%, 71%), hsl(225, 14%, 77%));
+  color: hsl(355, 76%, 59%);
 }
 meta.button.selected {
   color: hsl(355, 76%, 59%);
@@ -84,8 +84,8 @@ meta.document {
 }
 
 meta.document.button {
-  background: linear-gradient(hsl(223, 16%, 83%), hsl(225, 14%, 77%));
-  border: linear-gradient(hsl(223, 16%, 83%), hsl(225, 14%, 77%));
+  background: linear-gradient(hsl(225, 14%, 77%), hsl(223, 16%, 83%));
+  border: linear-gradient(hsl(225, 14%, 77%), hsl(223, 16%, 83%));
 }
 meta.document.button.disabled {
   background: linear-gradient(hsl(232, 10%, 53%), hsl(232, 10%, 53%));
@@ -105,7 +105,7 @@ meta.document.textfield.highlighted {
 
 /* Text */
 meta.text {
-  color: hsl(234, 16%, 35%);
+  color: hsl(234, 16%, 36%);
 }
 meta.text.invisible {
   color: hsl(225, 14%, 77%);
@@ -129,7 +129,7 @@ meta.gutter {
 }
 meta.gutter.selected {
   background-color: hsl(225, 14%, 77%);
-  color: hsl(223, 16%, 83%);
+  color: hsl(234, 16%, 36%);
 }
 
 /*
@@ -179,7 +179,7 @@ keyword.self {
   color: hsl(220, 91%, 54%);
 }
 keyword.self.prefix {
-  color: hsl(197, 97%, 46%);
+  color: hsl(197, 96%, 46%);
 }
 
 /* Values */
@@ -222,7 +222,7 @@ identifier.property.prefix {
 identifier.decorator,
 identifier.function,
 identifier.method {
-  color: hsl(197, 97%, 46%);
+  color: hsl(197, 96%, 46%);
 }
 identifier.key {
   color: hsl(231, 97%, 72%);
@@ -315,7 +315,7 @@ tag {
   color: hsl(183, 74%, 35%);
 }
 tag.name {
-  color: hsl(197, 97%, 46%);
+  color: hsl(197, 96%, 46%);
 }
 tag.framework {
   color: hsl(266, 85%, 58%);
@@ -330,7 +330,7 @@ tag.framework.attribute.name {
   color: hsl(316, 73%, 69%);
 }
 tag.attribute.value {
-  color: hsl(0, 60%, 67%);
+  color: hsl(0, 59%, 84%);
 }
 tag.attribute.value.delimiter {
   color: hsl(355, 76%, 59%);
@@ -378,11 +378,11 @@ style.value.color.named {
   color: hsl(220, 91%, 54%);
 }
 style.value.identifier.function {
-  color: hsl(197, 97%, 46%);
+  color: hsl(197, 96%, 46%);
 }
 
 terminal.black {
-  color: #5c5f77;
+  color: #bcc0cc;
 }
 terminal.blue {
   color: #1e66f5;
@@ -403,13 +403,13 @@ terminal.cyan {
   color: #179299;
 }
 terminal.white {
-  color: #acb0be;
-}
-terminal.bright-black {
   color: #6c6f85;
 }
+terminal.bright-black {
+  color: #acb0be;
+}
 terminal.bright-white {
-  color: #bcc0cc;
+  color: #6c6f85;
 }
 terminal.bright-blue {
   color: #1e66f5;

--- a/Themes/Catppuccin Macchiato.css
+++ b/Themes/Catppuccin Macchiato.css
@@ -6,12 +6,12 @@
   --mauve: hsl(267, 83%, 80%);
   --red: hsl(351, 74%, 73%);
   --maroon: hsl(355, 71%, 77%);
-  --peach: hsl(21, 86%, 73%);
+  --peach: hsl(21, 85%, 73%);
   --yellow: hsl(40, 70%, 78%);
   --green: hsl(105, 48%, 72%);
   --teal: hsl(171, 47%, 69%);
-  --sky: hsl(189, 59%, 73%);
-  --sapphire: hsl(199, 66%, 69%);
+  --sky: hsl(189, 60%, 73%);
+  --sapphire: hsl(199, 65%, 69%);
   --blue: hsl(220, 83%, 75%);
   --lavender: hsl(234, 82%, 85%);
   --text: hsl(227, 68%, 88%);
@@ -20,10 +20,10 @@
   --overlay2: hsl(228, 20%, 65%);
   --overlay1: hsl(228, 15%, 57%);
   --overlay0: hsl(230, 12%, 49%);
-  --surface2: hsl(230, 14%, 41%);
+  --surface2: hsl(230, 14%, 42%);
   --surface1: hsl(231, 16%, 34%);
   --surface0: hsl(230, 19%, 26%);
-  --base: hsl(232, 23%, 18%);
+  --base: hsl(232, 24%, 18%);
   --mantle: hsl(233, 23%, 15%);
   --crust: hsl(236, 23%, 12%);
 }
@@ -37,7 +37,7 @@ meta {
  * Window styles
  */
 meta.window {
-  background-color: hsl(232, 23%, 18%);
+  background-color: hsl(232, 24%, 18%);
   border-color: hsl(230, 19%, 26%);
 }
 meta.titlebar {
@@ -53,8 +53,8 @@ meta.button {
   color: hsl(10, 58%, 90%);
 }
 meta.button.highlighted {
-  background: linear-gradient(hsl(230, 14%, 41%), hsl(231, 16%, 34%));
-  border: linear-gradient(hsl(230, 14%, 41%), hsl(231, 16%, 34%));
+  background: linear-gradient(hsl(230, 14%, 42%), hsl(231, 16%, 34%));
+  border: linear-gradient(hsl(230, 14%, 42%), hsl(231, 16%, 34%));
   color: hsl(355, 71%, 77%);
 }
 meta.button.selected {
@@ -79,7 +79,7 @@ meta.textfield.highlighted {
  * Document styles
  */
 meta.document {
-  background-color: hsl(232, 23%, 18%);
+  background-color: hsl(232, 24%, 18%);
   border-color: hsl(228, 20%, 65%);
 }
 
@@ -91,7 +91,7 @@ meta.document.button.disabled {
   background: linear-gradient(hsl(228, 20%, 65%), hsl(228, 20%, 65%));
 }
 meta.document.button.highlighted {
-  background: linear-gradient(hsl(21, 86%, 73%), hsl(355, 71%, 77%));
+  background: linear-gradient(hsl(21, 85%, 73%), hsl(355, 71%, 77%));
 }
 
 meta.document.textfield {
@@ -148,10 +148,10 @@ bracket {
   color: hsl(105, 48%, 72%);
 }
 operator {
-  color: hsl(199, 66%, 69%);
+  color: hsl(199, 65%, 69%);
 }
 invalid {
-  background-color: hsl(21, 86%, 73%);
+  background-color: hsl(21, 85%, 73%);
   color: hsl(230, 19%, 26%);
 }
 link {
@@ -179,7 +179,7 @@ keyword.self {
   color: hsl(220, 83%, 75%);
 }
 keyword.self.prefix {
-  color: hsl(189, 59%, 73%);
+  color: hsl(189, 60%, 73%);
 }
 
 /* Values */
@@ -201,7 +201,7 @@ value.symbol {
 
 /* Identifiers */
 identifier.type {
-  color: hsl(21, 86%, 73%);
+  color: hsl(21, 85%, 73%);
 }
 identifier.constant,
 identifier.global,
@@ -211,7 +211,7 @@ identifier.variable {
 identifier.constant.prefix,
 identifier.global.prefix,
 identifier.variable.prefix {
-  color: hsl(199, 66%, 69%);
+  color: hsl(199, 65%, 69%);
 }
 identifier.property {
   color: hsl(10, 58%, 90%);
@@ -222,7 +222,7 @@ identifier.property.prefix {
 identifier.decorator,
 identifier.function,
 identifier.method {
-  color: hsl(189, 59%, 73%);
+  color: hsl(189, 60%, 73%);
 }
 identifier.key {
   color: hsl(234, 82%, 85%);
@@ -265,13 +265,13 @@ cdata {
 
 /* Markup */
 markup.heading {
-  color: hsl(21, 86%, 73%);
+  color: hsl(21, 85%, 73%);
 }
 markup.line {
   color: hsl(234, 82%, 85%);
 }
 markup.bold {
-  color: hsl(199, 66%, 69%);
+  color: hsl(199, 65%, 69%);
   font-weight: bold;
 }
 markup.italic {
@@ -282,7 +282,7 @@ markup.strikethrough {
   color: hsl(228, 20%, 65%);
 }
 markup.list.item {
-  color: hsl(21, 86%, 73%);
+  color: hsl(21, 85%, 73%);
 }
 markup.code {
   background-color: hsl(233, 23%, 15%);
@@ -315,7 +315,7 @@ tag {
   color: hsl(171, 47%, 69%);
 }
 tag.name {
-  color: hsl(189, 59%, 73%);
+  color: hsl(189, 60%, 73%);
 }
 tag.framework {
   color: hsl(267, 83%, 80%);
@@ -330,7 +330,7 @@ tag.framework.attribute.name {
   color: hsl(316, 74%, 85%);
 }
 tag.attribute.value {
-  color: hsl(0, 58%, 86%);
+  color: hsl(0, 59%, 84%);
 }
 tag.attribute.value.delimiter {
   color: hsl(355, 71%, 77%);
@@ -378,7 +378,7 @@ style.value.color.named {
   color: hsl(220, 83%, 75%);
 }
 style.value.identifier.function {
-  color: hsl(189, 59%, 73%);
+  color: hsl(189, 60%, 73%);
 }
 
 terminal.black {
@@ -403,7 +403,7 @@ terminal.cyan {
   color: #8bd5ca;
 }
 terminal.white {
-  color: #b8c0e0;
+  color: #a5adcb;
 }
 terminal.bright-black {
   color: #5b6078;

--- a/Themes/Catppuccin Mocha.css
+++ b/Themes/Catppuccin Mocha.css
@@ -1,31 +1,31 @@
 /* Mocha */
 :root {
-  --rosewater: hsla(10, 56%, 91%, 1);
-  --flamingo: hsla(0, 59%, 88%, 1);
-  --pink: hsla(316, 72%, 86%, 1);
-  --mauve: hsla(267, 84%, 81%, 1);
-  --red: hsla(343, 81%, 75%, 1);
-  --maroon: hsla(350, 65%, 77%, 1);
-  --peach: hsla(23, 92%, 75%, 1);
-  --yellow: hsla(41, 86%, 83%, 1);
-  --green: hsla(115, 54%, 76%, 1);
-  --teal: hsla(170, 57%, 73%, 1);
-  --sky: hsla(189, 71%, 73%, 1);
-  --sapphire: hsla(199, 76%, 69%, 1);
-  --blue: hsla(217, 92%, 76%, 1);
-  --lavender: hsla(232, 97%, 85%, 1);
-  --text: hsla(226, 64%, 88%, 1);
-  --subtext1: hsla(227, 35%, 80%, 1);
-  --subtext0: hsla(228, 24%, 72%, 1);
-  --overlay2: hsla(228, 17%, 64%, 1);
-  --overlay1: hsla(230, 13%, 55%, 1);
-  --overlay0: hsla(231, 11%, 47%, 1);
-  --surface2: hsla(233, 12%, 39%, 1);
-  --surface1: hsla(234, 13%, 31%, 1);
-  --surface0: hsla(237, 16%, 23%, 1);
-  --base: hsla(240, 21%, 15%, 1);
-  --mantle: hsla(240, 21%, 12%, 1);
-  --crust: hsla(240, 23%, 9%, 1);
+  --rosewater: hsl(10, 56%, 91%);
+  --flamingo: hsl(0, 59%, 88%);
+  --pink: hsl(316, 72%, 86%);
+  --mauve: hsl(267, 84%, 81%);
+  --red: hsl(343, 81%, 75%);
+  --maroon: hsl(350, 65%, 78%);
+  --peach: hsl(23, 92%, 76%);
+  --yellow: hsl(41, 86%, 83%);
+  --green: hsl(115, 54%, 76%);
+  --teal: hsl(170, 57%, 73%);
+  --sky: hsl(189, 71%, 73%);
+  --sapphire: hsl(199, 76%, 69%);
+  --blue: hsl(217, 92%, 76%);
+  --lavender: hsl(232, 97%, 85%);
+  --text: hsl(226, 64%, 88%);
+  --subtext1: hsl(227, 35%, 80%);
+  --subtext0: hsl(228, 24%, 72%);
+  --overlay2: hsl(228, 17%, 64%);
+  --overlay1: hsl(230, 13%, 56%);
+  --overlay0: hsl(231, 11%, 47%);
+  --surface2: hsl(233, 12%, 39%);
+  --surface1: hsl(234, 13%, 31%);
+  --surface0: hsl(237, 16%, 23%);
+  --base: hsl(240, 21%, 15%);
+  --mantle: hsl(240, 21%, 12%);
+  --crust: hsl(240, 23%, 9%);
 }
 
 meta {
@@ -37,258 +37,258 @@ meta {
  * Window styles
  */
 meta.window {
-  background-color: hsla(240, 21%, 15%, 1);
-  border-color: hsla(237, 16%, 23%, 1);
+  background-color: hsl(240, 21%, 15%);
+  border-color: hsl(237, 16%, 23%);
 }
 meta.titlebar {
-  color: hsla(228, 24%, 72%, 1);
-  border-color: hsla(237, 16%, 23%, 1);
+  color: hsl(228, 24%, 72%);
+  border-color: hsl(237, 16%, 23%);
 }
 meta.titlebar.inactive {
 }
 
 meta.button {
-  background: linear-gradient(hsla(234, 13%, 31%, 1), hsla(237, 16%, 23%, 1));
-  border: linear-gradient(hsla(234, 13%, 31%, 1), hsla(237, 16%, 23%, 1));
-  color: hsla(10, 56%, 91%, 1);
+  background: linear-gradient(hsl(234, 13%, 31%), hsl(237, 16%, 23%));
+  border: linear-gradient(hsl(234, 13%, 31%), hsl(237, 16%, 23%));
+  color: hsl(10, 56%, 91%);
 }
 meta.button.highlighted {
-  background: linear-gradient(hsla(233, 12%, 39%, 1), hsla(234, 13%, 31%, 1));
-  border: linear-gradient(hsla(233, 12%, 39%, 1), hsla(234, 13%, 31%, 1));
-  color: hsla(350, 65%, 77%, 1);
+  background: linear-gradient(hsl(233, 12%, 39%), hsl(234, 13%, 31%));
+  border: linear-gradient(hsl(233, 12%, 39%), hsl(234, 13%, 31%));
+  color: hsl(350, 65%, 78%);
 }
 meta.button.selected {
-  color: hsla(350, 65%, 77%, 1);
+  color: hsl(350, 65%, 78%);
 }
 meta.button.highlighted.selected {
-  color: hsla(240, 21%, 12%, 1);
+  color: hsl(240, 21%, 12%);
 }
 meta.button.disabled {
 }
 
 meta.textfield {
-  background-color: hsla(240, 21%, 12%, 1);
-  border-color: hsla(237, 16%, 23%, 1);
+  background-color: hsl(240, 21%, 12%);
+  border-color: hsl(237, 16%, 23%);
 }
 meta.textfield.highlighted {
-  background-color: hsla(240, 21%, 12%, 1);
-  border-color: hsla(234, 13%, 31%, 1);
+  background-color: hsl(240, 21%, 12%);
+  border-color: hsl(234, 13%, 31%);
 }
 
 /*
  * Document styles
  */
 meta.document {
-  background-color: hsla(240, 21%, 15%, 1);
-  border-color: hsla(228, 17%, 64%, 1);
+  background-color: hsl(240, 21%, 15%);
+  border-color: hsl(228, 17%, 64%);
 }
 
 meta.document.button {
-  background: linear-gradient(hsla(234, 13%, 31%, 1), hsla(237, 16%, 23%, 1));
-  border: linear-gradient(hsla(234, 13%, 31%, 1), hsla(237, 16%, 23%, 1));
+  background: linear-gradient(hsl(234, 13%, 31%), hsl(237, 16%, 23%));
+  border: linear-gradient(hsl(234, 13%, 31%), hsl(237, 16%, 23%));
 }
 meta.document.button.disabled {
-  background: linear-gradient(hsla(228, 17%, 64%, 1), hsla(228, 17%, 64%, 1));
+  background: linear-gradient(hsl(228, 17%, 64%), hsl(228, 17%, 64%));
 }
 meta.document.button.highlighted {
-  background: linear-gradient(hsla(23, 92%, 75%, 1), hsla(350, 65%, 77%, 1));
+  background: linear-gradient(hsl(23, 92%, 76%), hsl(350, 65%, 78%));
 }
 
 meta.document.textfield {
-  background-color: hsla(240, 21%, 12%, 1);
-  border-color: hsla(237, 16%, 23%, 1);
+  background-color: hsl(240, 21%, 12%);
+  border-color: hsl(237, 16%, 23%);
 }
 meta.document.textfield.highlighted {
-  background-color: hsla(240, 21%, 12%, 1);
-  border-color: hsla(234, 13%, 31%, 1);
+  background-color: hsl(240, 21%, 12%);
+  border-color: hsl(234, 13%, 31%);
 }
 
 /* Text */
 meta.text {
-  color: hsla(226, 64%, 88%, 1);
+  color: hsl(226, 64%, 88%);
 }
 meta.text.invisible {
-  color: hsla(234, 13%, 31%, 1);
+  color: hsl(234, 13%, 31%);
 }
 meta.text.selected {
 }
 
 /* Cursor */
 meta.cursor {
-  background-color: hsla(240, 21%, 12%, 1);
+  background-color: hsl(240, 21%, 12%);
 }
 
 /* Indentation Guides */
 meta.indentguide {
-  border-color: hsla(228, 17%, 64%, 1);
+  border-color: hsl(228, 17%, 64%);
 }
 
 /* Gutter */
 meta.gutter {
-  color: hsla(228, 17%, 64%, 1);
+  color: hsl(228, 17%, 64%);
 }
 meta.gutter.selected {
-  background-color: hsla(234, 13%, 31%, 1);
-  color: hsla(226, 64%, 88%, 1);
+  background-color: hsl(234, 13%, 31%);
+  color: hsl(226, 64%, 88%);
 }
 
 /*
  * Syntax styles
  */
 comment {
-  color: hsla(228, 17%, 64%, 1);
+  color: hsl(228, 17%, 64%);
 }
 processing {
-  color: hsla(228, 17%, 64%, 1);
+  color: hsl(228, 17%, 64%);
 }
 declaration {
-  color: hsla(170, 57%, 73%, 1);
+  color: hsl(170, 57%, 73%);
 }
 bracket {
-  color: hsla(115, 54%, 76%, 1);
+  color: hsl(115, 54%, 76%);
 }
 operator {
-  color: hsla(199, 76%, 69%, 1);
+  color: hsl(199, 76%, 69%);
 }
 invalid {
-  background-color: hsla(23, 92%, 75%, 1);
-  color: hsla(237, 16%, 23%, 1);
+  background-color: hsl(23, 92%, 76%);
+  color: hsl(237, 16%, 23%);
 }
 link {
-  color: hsla(217, 92%, 76%, 1);
+  color: hsl(217, 92%, 76%);
 }
 
 /* Keywords */
 keyword {
-  color: hsla(343, 81%, 75%, 1);
+  color: hsl(343, 81%, 75%);
 }
 keyword.modifier {
   font-style: italic;
-  color: hsla(170, 57%, 73%, 1);
+  color: hsl(170, 57%, 73%);
 }
 keyword.condition {
-  color: hsla(217, 92%, 76%, 1);
+  color: hsl(217, 92%, 76%);
 }
 keyword.construct {
-  color: hsla(217, 92%, 76%, 1);
+  color: hsl(217, 92%, 76%);
 }
 keyword.statement {
-  color: hsla(217, 92%, 76%, 1);
+  color: hsl(217, 92%, 76%);
 }
 keyword.self {
-  color: hsla(217, 92%, 76%, 1);
+  color: hsl(217, 92%, 76%);
 }
 keyword.self.prefix {
-  color: hsla(189, 71%, 73%, 1);
+  color: hsl(189, 71%, 73%);
 }
 
 /* Values */
 value.boolean {
-  color: hsla(217, 92%, 76%, 1);
+  color: hsl(217, 92%, 76%);
 }
 value.null {
-  color: hsla(217, 92%, 76%, 1);
+  color: hsl(217, 92%, 76%);
 }
 value.number {
-  color: hsla(10, 56%, 91%, 1);
+  color: hsl(10, 56%, 91%);
 }
 value.entity {
-  color: hsla(217, 92%, 76%, 1);
+  color: hsl(217, 92%, 76%);
 }
 value.symbol {
-  color: hsla(217, 92%, 76%, 1);
+  color: hsl(217, 92%, 76%);
 }
 
 /* Identifiers */
 identifier.type {
-  color: hsla(23, 92%, 75%, 1);
+  color: hsl(23, 92%, 76%);
 }
 identifier.constant,
 identifier.global,
 identifier.variable {
-  color: hsla(232, 97%, 85%, 1);
+  color: hsl(232, 97%, 85%);
 }
 identifier.constant.prefix,
 identifier.global.prefix,
 identifier.variable.prefix {
-  color: hsla(199, 76%, 69%, 1);
+  color: hsl(199, 76%, 69%);
 }
 identifier.property {
-  color: hsla(10, 56%, 91%, 1);
+  color: hsl(10, 56%, 91%);
 }
 identifier.property.prefix {
-  color: hsla(237, 16%, 23%, 1);
+  color: hsl(237, 16%, 23%);
 }
 identifier.decorator,
 identifier.function,
 identifier.method {
-  color: hsla(189, 71%, 73%, 1);
+  color: hsl(189, 71%, 73%);
 }
 identifier.key {
-  color: hsla(232, 97%, 85%, 1);
+  color: hsl(232, 97%, 85%);
 }
 identifier.argument {
-  color: hsla(232, 97%, 85%, 1);
+  color: hsl(232, 97%, 85%);
 }
 identifier.argument.prefix {
-  color: hsla(237, 16%, 23%, 1);
+  color: hsl(237, 16%, 23%);
 }
 
 /* Strings */
 string {
-  color: hsla(115, 54%, 76%, 1);
+  color: hsl(115, 54%, 76%);
 }
 string.delimiter {
-  color: hsla(343, 81%, 75%, 1);
+  color: hsl(343, 81%, 75%);
 }
 string.escape {
-  color: hsla(10, 56%, 91%, 1);
+  color: hsl(10, 56%, 91%);
 }
 string.key {
-  color: hsla(232, 97%, 85%, 1);
+  color: hsl(232, 97%, 85%);
 }
 string-keyword {
-  color: hsla(237, 16%, 23%, 1);
+  color: hsl(237, 16%, 23%);
 }
 string-template {
-  color: hsla(41, 86%, 83%, 1);
+  color: hsl(41, 86%, 83%);
 }
 regex {
-  color: hsla(41, 86%, 83%, 1);
+  color: hsl(41, 86%, 83%);
 }
 regex.escape {
-  color: hsla(41, 86%, 83%, 1);
+  color: hsl(41, 86%, 83%);
 }
 cdata {
-  color: hsla(217, 92%, 76%, 1);
+  color: hsl(217, 92%, 76%);
 }
 
 /* Markup */
 markup.heading {
-  color: hsla(23, 92%, 75%, 1);
+  color: hsl(23, 92%, 76%);
 }
 markup.line {
-  color: hsla(232, 97%, 85%, 1);
+  color: hsl(232, 97%, 85%);
 }
 markup.bold {
-  color: hsla(199, 76%, 69%, 1);
+  color: hsl(199, 76%, 69%);
   font-weight: bold;
 }
 markup.italic {
-  color: hsla(232, 97%, 85%, 1);
+  color: hsl(232, 97%, 85%);
   font-style: italic;
 }
 markup.strikethrough {
-  color: hsla(228, 17%, 64%, 1);
+  color: hsl(228, 17%, 64%);
 }
 markup.list.item {
-  color: hsla(23, 92%, 75%, 1);
+  color: hsl(23, 92%, 76%);
 }
 markup.code {
-  background-color: hsla(240, 21%, 12%, 1);
+  background-color: hsl(240, 21%, 12%);
 }
 markup.link {
-  color: hsla(217, 92%, 76%, 1);
+  color: hsl(217, 92%, 76%);
 }
 
 /* Types */
@@ -298,87 +298,87 @@ definition.package.name,
 definition.enum.name,
 definition.union.name,
 definition.struct.name {
-  color: hsla(170, 57%, 73%, 1);
+  color: hsl(170, 57%, 73%);
 }
 
 /* Members */
 definition.property.name {
-  color: hsla(170, 57%, 73%, 1);
+  color: hsl(170, 57%, 73%);
 }
 definition.function.name,
 definition.method.name {
-  color: hsla(170, 57%, 73%, 1);
+  color: hsl(170, 57%, 73%);
 }
 
 /* Tags */
 tag {
-  color: hsla(170, 57%, 73%, 1);
+  color: hsl(170, 57%, 73%);
 }
 tag.name {
-  color: hsla(189, 71%, 73%, 1);
+  color: hsl(189, 71%, 73%);
 }
 tag.framework {
-  color: hsla(267, 84%, 81%, 1);
+  color: hsl(267, 84%, 81%);
 }
 tag.framework.name {
-  color: hsla(267, 84%, 81%, 1);
+  color: hsl(267, 84%, 81%);
 }
 tag.attribute.name {
-  color: hsla(232, 97%, 85%, 1);
+  color: hsl(232, 97%, 85%);
 }
 tag.framework.attribute.name {
-  color: hsla(316, 72%, 86%, 1);
+  color: hsl(316, 72%, 86%);
 }
 tag.attribute.value {
-  color: hsla(0, 59%, 88%, 1);
+  color: hsl(0, 59%, 84%);
 }
 tag.attribute.value.delimiter {
-  color: hsla(350, 65%, 77%, 1);
+  color: hsl(350, 65%, 78%);
 }
 tag.attribute.operator {
-  color: hsla(230, 13%, 55%, 1);
+  color: hsl(230, 13%, 56%);
 }
 tag.attribute.value.link {
-  color: hsla(217, 92%, 76%, 1);
+  color: hsl(217, 92%, 76%);
 }
 
 /* Styles */
 style.at {
-  color: hsla(41, 86%, 83%, 1);
+  color: hsl(41, 86%, 83%);
   font-weight: bold;
 }
 style.selector.element {
   font-weight: bold;
 }
 style.selector.identifier.id {
-  color: hsla(41, 86%, 83%, 1);
+  color: hsl(41, 86%, 83%);
 }
 style.selector.identifier.class {
-  color: hsla(232, 97%, 85%, 1);
+  color: hsl(232, 97%, 85%);
 }
 style.selector.pseudoclass {
-  color: hsla(232, 97%, 85%, 1);
+  color: hsl(232, 97%, 85%);
 }
 style.selector.pseudoelement {
-  color: hsla(41, 86%, 83%, 1);
+  color: hsl(41, 86%, 83%);
 }
 style.attribute.name {
-  color: hsla(170, 57%, 73%, 1);
+  color: hsl(170, 57%, 73%);
 }
 style.value.number {
-  color: hsla(10, 56%, 91%, 1);
+  color: hsl(10, 56%, 91%);
 }
 style.value.color.hex {
-  color: hsla(316, 72%, 86%, 1);
+  color: hsl(316, 72%, 86%);
 }
 style.value.keyword {
-  color: hsla(217, 92%, 76%, 1);
+  color: hsl(217, 92%, 76%);
 }
 style.value.color.named {
-  color: hsla(217, 92%, 76%, 1);
+  color: hsl(217, 92%, 76%);
 }
 style.value.identifier.function {
-  color: hsla(189, 71%, 73%, 1);
+  color: hsl(189, 71%, 73%);
 }
 
 terminal.black {
@@ -403,7 +403,7 @@ terminal.cyan {
   color: #94e2d5;
 }
 terminal.white {
-  color: #bac2de;
+  color: #a6adc8;
 }
 terminal.bright-black {
   color: #585b70;

--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+_default:
+  @just --list
+
+build:
+  whiskers nova.tera

--- a/justfile
+++ b/justfile
@@ -1,5 +1,0 @@
-_default:
-  @just --list
-
-build:
-  whiskers nova.tera

--- a/nova.tera
+++ b/nova.tera
@@ -1,0 +1,415 @@
+---
+whiskers:
+  version: "2.3.0"
+  matrix:
+    - flavor
+  filename: "Themes/Catppuccin {{ flavor.identifier | capitalize }}.css"
+---
+/* {{ flavor.name }} */
+:root {
+{%- for _, color in flavor.colors %}
+  --{{ color.identifier }}: {{ color | css_hsl }};
+{%- endfor %}
+}
+
+meta {
+  -theme-interface-style: dark;
+  -theme-accent-color: hsl(0, 59%, 88%);
+}
+
+/*
+ * Window styles
+ */
+meta.window {
+  background-color: {{ base | css_hsl }};
+  border-color: {{ surface0 | css_hsl }};
+}
+meta.titlebar {
+  color: {{ subtext0 | css_hsl }};
+  border-color: {{ surface0 | css_hsl }};
+}
+meta.titlebar.inactive {
+}
+
+meta.button {
+  background: linear-gradient({{ surface1 | css_hsl }}, {{ surface0 | css_hsl }});
+  border: linear-gradient({{ surface1 | css_hsl }}, {{ surface0 | css_hsl }});
+  color: {{ rosewater | css_hsl }};
+}
+meta.button.highlighted {
+  background: linear-gradient({{ surface2 | css_hsl }}, {{ surface1 | css_hsl }});
+  border: linear-gradient({{ surface2 | css_hsl }}, {{ surface1 | css_hsl }});
+  color: {{ maroon | css_hsl }};
+}
+meta.button.selected {
+  color: {{ maroon | css_hsl }};
+}
+meta.button.highlighted.selected {
+  color: {{ mantle | css_hsl }};
+}
+meta.button.disabled {
+}
+
+meta.textfield {
+  background-color: {{ mantle | css_hsl }};
+  border-color: {{ surface0 | css_hsl }};
+}
+meta.textfield.highlighted {
+  background-color: {{ mantle | css_hsl }};
+  border-color: {{ surface1 | css_hsl }};
+}
+
+/*
+ * Document styles
+ */
+meta.document {
+  background-color: {{ base | css_hsl }};
+  border-color: {{ overlay2 | css_hsl }};
+}
+
+meta.document.button {
+  background: linear-gradient({{ surface1 | css_hsl }}, {{ surface0 | css_hsl }});
+  border: linear-gradient({{ surface1 | css_hsl }}, {{ surface0 | css_hsl }});
+}
+meta.document.button.disabled {
+  background: linear-gradient({{ overlay2 | css_hsl }}, {{ overlay2 | css_hsl }});
+}
+meta.document.button.highlighted {
+  background: linear-gradient({{ peach | css_hsl }}, {{ maroon | css_hsl }});
+}
+
+meta.document.textfield {
+  background-color: {{ mantle | css_hsl }};
+  border-color: {{ surface0 | css_hsl }};
+}
+meta.document.textfield.highlighted {
+  background-color: {{ mantle | css_hsl }};
+  border-color: {{ surface1 | css_hsl }};
+}
+
+/* Text */
+meta.text {
+  color: {{ text | css_hsl }};
+}
+meta.text.invisible {
+  color: {{ surface1 | css_hsl }};
+}
+meta.text.selected {
+}
+
+/* Cursor */
+meta.cursor {
+  background-color: {{ mantle | css_hsl }};
+}
+
+/* Indentation Guides */
+meta.indentguide {
+  border-color: {{ overlay2 | css_hsl }};
+}
+
+/* Gutter */
+meta.gutter {
+  color: {{ overlay2 | css_hsl }};
+}
+meta.gutter.selected {
+  background-color: {{ surface1 | css_hsl }};
+  color: {{ text | css_hsl }};
+}
+
+/*
+ * Syntax styles
+ */
+comment {
+  color: {{ overlay2 | css_hsl }};
+}
+processing {
+  color: {{ overlay2 | css_hsl }};
+}
+declaration {
+  color: {{ teal | css_hsl }};
+}
+bracket {
+  color: {{ green | css_hsl }};
+}
+operator {
+  color: {{ sapphire | css_hsl }};
+}
+invalid {
+  background-color: {{ peach | css_hsl }};
+  color: {{ surface0 | css_hsl }};
+}
+link {
+  color: {{ blue | css_hsl }};
+}
+
+/* Keywords */
+keyword {
+  color: {{ red | css_hsl }};
+}
+keyword.modifier {
+  font-style: italic;
+  color: {{ teal | css_hsl }};
+}
+keyword.condition {
+  color: {{ blue | css_hsl }};
+}
+keyword.construct {
+  color: {{ blue | css_hsl }};
+}
+keyword.statement {
+  color: {{ blue | css_hsl }};
+}
+keyword.self {
+  color: {{ blue | css_hsl }};
+}
+keyword.self.prefix {
+  color: {{ sky | css_hsl }};
+}
+
+/* Values */
+value.boolean {
+  color: {{ blue | css_hsl }};
+}
+value.null {
+  color: {{ blue | css_hsl }};
+}
+value.number {
+  color: {{ rosewater | css_hsl }};
+}
+value.entity {
+  color: {{ blue | css_hsl }};
+}
+value.symbol {
+  color: {{ blue | css_hsl }};
+}
+
+/* Identifiers */
+identifier.type {
+  color: {{ peach | css_hsl }};
+}
+identifier.constant,
+identifier.global,
+identifier.variable {
+  color: {{ lavender | css_hsl }};
+}
+identifier.constant.prefix,
+identifier.global.prefix,
+identifier.variable.prefix {
+  color: {{ sapphire | css_hsl }};
+}
+identifier.property {
+  color: {{ rosewater | css_hsl }};
+}
+identifier.property.prefix {
+  color: {{ surface0 | css_hsl }};
+}
+identifier.decorator,
+identifier.function,
+identifier.method {
+  color: {{ sky | css_hsl }};
+}
+identifier.key {
+  color: {{ lavender | css_hsl }};
+}
+identifier.argument {
+  color: {{ lavender | css_hsl }};
+}
+identifier.argument.prefix {
+  color: {{ surface0 | css_hsl }};
+}
+
+/* Strings */
+string {
+  color: {{ green | css_hsl }};
+}
+string.delimiter {
+  color: {{ red | css_hsl }};
+}
+string.escape {
+  color: {{ rosewater | css_hsl }};
+}
+string.key {
+  color: {{ lavender | css_hsl }};
+}
+string-keyword {
+  color: {{ surface0 | css_hsl }};
+}
+string-template {
+  color: {{ yellow | css_hsl }};
+}
+regex {
+  color: {{ yellow | css_hsl }};
+}
+regex.escape {
+  color: {{ yellow | css_hsl }};
+}
+cdata {
+  color: {{ blue | css_hsl }};
+}
+
+/* Markup */
+markup.heading {
+  color: {{ peach | css_hsl }};
+}
+markup.line {
+  color: {{ lavender | css_hsl }};
+}
+markup.bold {
+  color: {{ sapphire | css_hsl }};
+  font-weight: bold;
+}
+markup.italic {
+  color: {{ lavender | css_hsl }};
+  font-style: italic;
+}
+markup.strikethrough {
+  color: {{ overlay2 | css_hsl }};
+}
+markup.list.item {
+  color: {{ peach | css_hsl }};
+}
+markup.code {
+  background-color: {{ mantle | css_hsl }};
+}
+markup.link {
+  color: {{ blue | css_hsl }};
+}
+
+/* Types */
+definition.class.name,
+definition.type.name,
+definition.package.name,
+definition.enum.name,
+definition.union.name,
+definition.struct.name {
+  color: {{ teal | css_hsl }};
+}
+
+/* Members */
+definition.property.name {
+  color: {{ teal | css_hsl }};
+}
+definition.function.name,
+definition.method.name {
+  color: {{ teal | css_hsl }};
+}
+
+/* Tags */
+tag {
+  color: {{ teal | css_hsl }};
+}
+tag.name {
+  color: {{ sky | css_hsl }};
+}
+tag.framework {
+  color: {{ mauve | css_hsl }};
+}
+tag.framework.name {
+  color: {{ mauve | css_hsl }};
+}
+tag.attribute.name {
+  color: {{ lavender | css_hsl }};
+}
+tag.framework.attribute.name {
+  color: {{ pink | css_hsl }};
+}
+tag.attribute.value {
+  color: hsl(0, 59%, 84%);
+}
+tag.attribute.value.delimiter {
+  color: {{ maroon | css_hsl }};
+}
+tag.attribute.operator {
+  color: {{ overlay1 | css_hsl }};
+}
+tag.attribute.value.link {
+  color: {{ blue | css_hsl }};
+}
+
+/* Styles */
+style.at {
+  color: {{ yellow | css_hsl }};
+  font-weight: bold;
+}
+style.selector.element {
+  font-weight: bold;
+}
+style.selector.identifier.id {
+  color: {{ yellow | css_hsl }};
+}
+style.selector.identifier.class {
+  color: {{ lavender | css_hsl }};
+}
+style.selector.pseudoclass {
+  color: {{ lavender | css_hsl }};
+}
+style.selector.pseudoelement {
+  color: {{ yellow | css_hsl }};
+}
+style.attribute.name {
+  color: {{ teal | css_hsl }};
+}
+style.value.number {
+  color: {{ rosewater | css_hsl }};
+}
+style.value.color.hex {
+  color: {{ pink | css_hsl }};
+}
+style.value.keyword {
+  color: {{ blue | css_hsl }};
+}
+style.value.color.named {
+  color: {{ blue | css_hsl }};
+}
+style.value.identifier.function {
+  color: {{ sky | css_hsl }};
+}
+
+terminal.black {
+  color: #{{ surface1.hex }};
+}
+terminal.blue {
+  color: #{{ blue.hex }};
+}
+terminal.red {
+  color: #{{ red.hex }};
+}
+terminal.green {
+  color: #{{ green.hex }};
+}
+terminal.yellow {
+  color: #{{ yellow.hex }};
+}
+terminal.magenta {
+  color: #{{ pink.hex }};
+}
+terminal.cyan {
+  color: #{{ teal.hex }};
+}
+terminal.white {
+  color: #{{ subtext0.hex }};
+}
+terminal.bright-black {
+  color: #{{ surface2.hex }};
+}
+terminal.bright-white {
+  color: #{{ subtext0.hex }};
+}
+terminal.bright-blue {
+  color: #{{ blue.hex }};
+}
+terminal.bright-red {
+  color: #{{ red.hex }};
+}
+terminal.bright-green {
+  color: #{{ green.hex }};
+}
+terminal.bright-yellow {
+  color: #{{ yellow.hex }};
+}
+terminal.bright-magenta {
+  color: #{{ pink.hex }};
+}
+terminal.bright-cyan {
+  color: #{{ teal.hex }};
+}


### PR DESCRIPTION
Adds [Whiskers](https://github.com/catppuccin/toolbox/tree/main/whiskers), Catppuccin's internal templating tool, to build the themes. Instead of editing the `.css` files directly, edit the `nova.tera` file and then run `whiskers nova.tera` to build the output themes. You will need Whiskers (linked above) installed.